### PR TITLE
Disallow cross-sign Moon applications

### DIFF
--- a/codexhorary1/backend/horary_constants.yaml
+++ b/codexhorary1/backend/horary_constants.yaml
@@ -76,8 +76,7 @@ moon:
   void_gating: false  # R26 gating disabled in favor of confidence penalty
   void_penalty: 10    # Confidence penalty applied when Moon is void-of-course
 
-  # Allow Moon applications that perfect after a sign change
-  allow_out_of_sign_applications: true
+  # Out-of-sign applications are ignored; cross-sign perfection is disallowed
 
   # Translation and collection requirements
   translation:

--- a/codexhorary1/backend/horary_engine/aspects.py
+++ b/codexhorary1/backend/horary_engine/aspects.py
@@ -72,9 +72,11 @@ def calculate_moon_next_aspect(
     jd_ut: float,
     get_moon_speed: Callable[[float], float],
 ) -> Optional[LunarAspect]:
-    """Calculate Moon's next applying aspect"""
-    config = cfg()
-    allow_cross_sign = getattr(config.moon, "allow_out_of_sign_applications", True)
+    """Calculate Moon's next applying aspect.
+
+    Cross-sign perfection is disallowed; aspects must perfect before the Moon
+    changes signs.
+    """
 
     moon_pos = planets[Planet.MOON]
     moon_speed = get_moon_speed(jd_ut)
@@ -109,10 +111,9 @@ def calculate_moon_next_aspect(
                         else float("inf")
                     )
 
-                    # Skip aspects that perfect after Moon leaves sign when not allowed
+                    # Skip aspects that perfect after Moon leaves its current sign
                     if (
-                        not allow_cross_sign
-                        and moon_days_to_exit is not None
+                        moon_days_to_exit is not None
                         and time_to_exact > moon_days_to_exit
                     ):
                         continue

--- a/codexhorary1/backend/tests/test_cross_sign.py
+++ b/codexhorary1/backend/tests/test_cross_sign.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from backend.horary_engine.aspects import calculate_moon_next_aspect
+from models import Planet, PlanetPosition, Sign
+
+
+def test_cross_sign_perfection_disallowed():
+    planets = {
+        Planet.MOON: PlanetPosition(
+            planet=Planet.MOON,
+            longitude=29.0,
+            latitude=0.0,
+            house=1,
+            sign=Sign.ARIES,
+            dignity_score=0,
+            speed=13.0,
+        ),
+        Planet.SUN: PlanetPosition(
+            planet=Planet.SUN,
+            longitude=31.0,
+            latitude=0.0,
+            house=1,
+            sign=Sign.TAURUS,
+            dignity_score=0,
+            speed=1.0,
+        ),
+    }
+
+    aspect = calculate_moon_next_aspect(planets, jd_ut=0.0, get_moon_speed=lambda _: 13.0)
+    assert aspect is None
+


### PR DESCRIPTION
## Summary
- drop `allow_out_of_sign_applications` config and document that cross-sign perfection is disallowed
- enforce sign-bound perfection in `calculate_moon_next_aspect`
- add test proving cross-sign application is ignored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5945d8eb883248ac8b1b6a2f2aa7b