### PR TITLE
chore: remove legacy void-of-course config

### DIFF
--- a/codexhorary1/backend/horary_config.py
+++ b/codexhorary1/backend/horary_config.py
@@ -131,7 +131,6 @@ class HoraryConfig:
         required_keys = [
             'timing.default_moon_speed_fallback',
             'orbs.conjunction',
-            'moon.void_rule',
             'confidence.base_confidence',
             'confidence.lunar_confidence_caps.favorable',
             'confidence.lunar_confidence_caps.unfavorable',

--- a/codexhorary1/backend/horary_constants.yaml
+++ b/codexhorary1/backend/horary_constants.yaml
@@ -42,9 +42,6 @@ orbs:
   cazimi_orb_arcmin: 17  # arcminutes
   combustion_orb: 8.5    # degrees
   under_beams_orb: 15.0  # degrees
-  
-  # Void-of-course orbs by method
-  void_orb_deg: 1.0  # for "by_orb" method
 
 moon:
   # Moon testimony and accidental dignity modifiers

--- a/codexhorary1/backend/horary_engine/engine.py
+++ b/codexhorary1/backend/horary_engine/engine.py
@@ -2307,7 +2307,7 @@ class EnhancedTraditionalHoraryJudgmentEngine:
     
     def _check_enhanced_moon_testimony(self, chart: HoraryChart, querent: Planet, quesited: Planet,
                                      ignore_void_moon: bool = False) -> Dict[str, Any]:
-        """Enhanced Moon testimony with configurable void-of-course methods"""
+        """Enhanced Moon testimony using the traditional void-of-course rule"""
         
         moon_pos = chart.planets[Planet.MOON]
         config = cfg()
@@ -4470,7 +4470,6 @@ def get_configuration_info() -> Dict[str, Any]:
                 "max_future_days": config.get('timing.max_future_days')
             },
             "moon": {
-                "void_rule": config.get('moon.void_rule'),
                 "translation_require_speed": config.get('moon.translation.require_speed_advantage', True)
             },
             "confidence": {

--- a/codexhorary1/frontend/src/App.jsx
+++ b/codexhorary1/frontend/src/App.jsx
@@ -4615,7 +4615,6 @@ const Settings = ({ darkMode, toggleDarkMode, setCurrentView, apiStatus, onRefre
           type: "group",
           items: [
             { name: "Void Penalty", type: "slider", value: 10, min: 0, max: 30, step: 1 },
-            { name: "Void Rule", type: "select", options: ["by_sign", "by_orb", "lilly"], value: "by_sign" },
             { name: "Moon in Cancer Exception", type: "toggle", value: true },
             { name: "Moon in Sagittarius Exception", type: "toggle", value: true }
           ]


### PR DESCRIPTION
## Summary
- drop unused void-of-course rule configs
- strip `moon.void_rule` from required config keys
- clean up API and UI to show only traditional void-of-course implementation

## Testing
- `python -m pytest codexhorary1/backend/tests -q`
- `npm test` *(fails: Cannot find module '/workspace/codex2080/codexhorary1/frontend/tests/buildChartPayload.test.mjs')*


------
https://chatgpt.com/codex/tasks/task_e_68a5a092eaec832496e4010fd725ce39