### PR TITLE
Use relative imports within backend

### DIFF
--- a/codexhorary1/backend/category_router.py
+++ b/codexhorary1/backend/category_router.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.models import Planet
-from backend.taxonomy import Category, get_defaults, resolve_category
+try:
+    from .models import Planet
+    from .taxonomy import Category, get_defaults, resolve_category
+except ImportError:  # pragma: no cover - fallback when executed as script
+    from models import Planet
+    from taxonomy import Category, get_defaults, resolve_category
 
 
 def get_contract(category: str | Category) -> Dict[str, Planet]:

--- a/codexhorary1/backend/evaluate_chart.py
+++ b/codexhorary1/backend/evaluate_chart.py
@@ -9,11 +9,11 @@ import sys
 # Ensure repository root on path when executed directly
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from backend.category_router import get_contract
-from backend.horary_engine.engine import extract_testimonies
-from backend.horary_engine.aggregator import aggregate
-from backend.horary_engine.rationale import build_rationale
-from backend.horary_engine.utils import token_to_string
+from .category_router import get_contract
+from .horary_engine.engine import extract_testimonies
+from .horary_engine.aggregator import aggregate
+from .horary_engine.rationale import build_rationale
+from .horary_engine.utils import token_to_string
 
 logger = logging.getLogger(__name__)
 

--- a/codexhorary1/backend/horary_engine/engine.py
+++ b/codexhorary1/backend/horary_engine/engine.py
@@ -107,7 +107,10 @@ from models import (
     HoraryChart,
 )
 from question_analyzer import TraditionalHoraryQuestionAnalyzer
-from backend.taxonomy import Category, resolve_category
+try:
+    from ..taxonomy import Category, resolve_category
+except ImportError:  # pragma: no cover - fallback when package context is missing
+    from taxonomy import Category, resolve_category
 from .reception import TraditionalReceptionCalculator
 from .aspects import (
     calculate_enhanced_aspects,

--- a/codexhorary1/backend/question_analyzer.py
+++ b/codexhorary1/backend/question_analyzer.py
@@ -2,7 +2,10 @@ from typing import Dict, Any, List
 import re
 import logging
 
-from backend.taxonomy import Category
+try:
+    from .taxonomy import Category
+except ImportError:  # pragma: no cover - fallback for script execution
+    from taxonomy import Category
 
 logger = logging.getLogger(__name__)
 

--- a/codexhorary1/backend/taxonomy.py
+++ b/codexhorary1/backend/taxonomy.py
@@ -4,7 +4,10 @@ import logging
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from backend.models import Planet
+try:
+    from .models import Planet
+except ImportError:  # pragma: no cover - fallback when executed as script
+    from models import Planet
 
 logger = logging.getLogger(__name__)
 

--- a/codexhorary1/backend/tests/test_cross_sign.py
+++ b/codexhorary1/backend/tests/test_cross_sign.py
@@ -5,8 +5,15 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-from backend.horary_engine.aspects import calculate_moon_next_aspect
-from models import Planet, PlanetPosition, Sign
+try:
+    from ..horary_engine.aspects import calculate_moon_next_aspect
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from horary_engine.aspects import calculate_moon_next_aspect
+
+try:
+    from ..models import Planet, PlanetPosition, Sign
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from models import Planet, PlanetPosition, Sign
 
 
 def test_cross_sign_perfection_disallowed():

--- a/codexhorary1/backend/tests/test_taxonomy.py
+++ b/codexhorary1/backend/tests/test_taxonomy.py
@@ -6,9 +6,14 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-from backend.taxonomy import Category, resolve_category
-from backend.category_router import get_contract
-from backend.models import Planet
+try:
+    from ..taxonomy import Category, resolve_category
+    from ..category_router import get_contract
+    from ..models import Planet
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from taxonomy import Category, resolve_category
+    from category_router import get_contract
+    from models import Planet
 
 
 def test_resolve_category_warns_deprecated(caplog):


### PR DESCRIPTION
## Summary
- Replace absolute `backend` imports with relative imports across backend modules
- Add fallbacks so modules can be run standalone
- Update tests to use package-relative imports

## Testing
- `python backend/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5a475e95c8324b0cf99b2c629b40c