### PR TITLE
Remove Void Moon override and always compute void-of-course

### DIFF
--- a/codexhorary1/Will I recover the stolen bicycle.json
+++ b/codexhorary1/Will I recover the stolen bicycle.json
@@ -734,8 +734,7 @@
     "override_flags_applied": {
       "ignore_combustion": false,
       "ignore_radicality": false,
-      "ignore_saturn_7th": false,
-      "ignore_void_moon": false
+      "ignore_saturn_7th": false
     },
     "timestamp": "2025-08-20T09:00:17.041001+00:00"
   },

--- a/codexhorary1/Will my loan application be approved.json
+++ b/codexhorary1/Will my loan application be approved.json
@@ -716,8 +716,7 @@
     "override_flags_applied": {
       "ignore_combustion": false,
       "ignore_radicality": false,
-      "ignore_saturn_7th": false,
-      "ignore_void_moon": false
+      "ignore_saturn_7th": false
     },
     "timestamp": "2025-08-20T08:04:01.184920+00:00"
   },

--- a/codexhorary1/Will my paper be accepted to the conference.json
+++ b/codexhorary1/Will my paper be accepted to the conference.json
@@ -660,8 +660,7 @@
     "override_flags_applied": {
       "ignore_combustion": false,
       "ignore_radicality": false,
-      "ignore_saturn_7th": false,
-      "ignore_void_moon": false
+      "ignore_saturn_7th": false
     },
     "timestamp": "2025-08-20T08:12:57.922838+00:00"
   },

--- a/codexhorary1/backend/app.py
+++ b/codexhorary1/backend/app.py
@@ -68,6 +68,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _safe_log_str(text: str) -> str:
+    """Return an ASCII-safe representation for logging."""
+    return text.encode("ascii", errors="backslashreplace").decode("ascii")
+
 
 app = Flask(__name__)
 
@@ -734,8 +738,6 @@ def calculate_chart():
 
         ignore_radicality = data.get('ignoreRadicality', False)
 
-        ignore_void_moon = data.get('ignoreVoidMoon', False)
-
         ignore_combustion = data.get('ignoreCombustion', False)
 
         ignore_saturn_7th = data.get('ignoreSaturn7th', False)
@@ -744,27 +746,27 @@ def calculate_chart():
 
         
 
-        logger.info(f"ENHANCED chart calculation request:")
+        logger.info("ENHANCED chart calculation request:")
 
-        logger.info(f"  Question: {question[:100]}..." if len(question) > 100 else f"  Question: {question}")
+        log_question = _safe_log_str(question[:100]) + "..." if len(question) > 100 else _safe_log_str(question)
+        logger.info("  Question: %s", log_question)
 
-        logger.info(f"  Location: {location}")
+        logger.info("  Location: %s", _safe_log_str(location))
 
-        logger.info(f"  Date: {date_str}")
+        logger.info("  Date: %s", date_str)
 
-        logger.info(f"  Time: {time_str}")
+        logger.info("  Time: %s", time_str)
 
-        logger.info(f"  Timezone: {timezone_str}")
+        logger.info("  Timezone: %s", timezone_str)
 
-        logger.info(f"  Use current time: {use_current_time}")
+        logger.info("  Use current time: %s", use_current_time)
 
         
 
         # NEW: Log enhanced parameters
 
-        if any([ignore_radicality, ignore_void_moon, ignore_combustion, ignore_saturn_7th]):
-
-            logger.info(f"  Override flags: radicality={ignore_radicality}, void_moon={ignore_void_moon}, combustion={ignore_combustion}, saturn_7th={ignore_saturn_7th}")
+        if any([ignore_radicality, ignore_combustion, ignore_saturn_7th]):
+            logger.info(f"  Override flags: radicality={ignore_radicality}, combustion={ignore_combustion}, saturn_7th={ignore_saturn_7th}")
 
         if exaltation_confidence_boost != 15.0:
 
@@ -891,9 +893,6 @@ def calculate_chart():
                 # NEW: Enhanced features
 
                 "ignore_radicality": ignore_radicality,
-
-                "ignore_void_moon": ignore_void_moon,
-
                 "ignore_combustion": ignore_combustion,
 
                 "ignore_saturn_7th": ignore_saturn_7th,
@@ -981,8 +980,6 @@ def calculate_chart():
             'override_flags_applied': {
 
                 'ignore_radicality': ignore_radicality,
-
-                'ignore_void_moon': ignore_void_moon,
 
                 'ignore_combustion': ignore_combustion,
 
@@ -1117,8 +1114,6 @@ def moon_debug():
             },
 
             'new_override_options': {
-
-                'ignore_void_moon': 'Set to true to bypass void Moon restrictions',
 
                 'ignore_combustion': 'Set to true to ignore solar condition penalties'
 

--- a/codexhorary1/frontend/src/App.jsx
+++ b/codexhorary1/frontend/src/App.jsx
@@ -1265,7 +1265,6 @@ const EnhancedChartCasting = ({ setCurrentChart, setCurrentView, darkMode, apiSt
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [advancedOptions, setAdvancedOptions] = useState({
     ignoreRadicality: false,
-    ignoreVoidMoon: false,
     ignoreCombustion: false,
     ignoreSaturn7th: false,
     exaltationConfidenceBoost: 15.0
@@ -1362,7 +1361,6 @@ const EnhancedChartCasting = ({ setCurrentChart, setCurrentView, darkMode, apiSt
         // NEW: Include enhanced options if API is connected
         ...(apiStatus === 'connected' && {
           ignoreRadicality: advancedOptions.ignoreRadicality,
-          ignoreVoidMoon: advancedOptions.ignoreVoidMoon,
           ignoreCombustion: advancedOptions.ignoreCombustion,
           ignoreSaturn7th: advancedOptions.ignoreSaturn7th,
           exaltationConfidenceBoost: advancedOptions.exaltationConfidenceBoost
@@ -1485,7 +1483,6 @@ const EnhancedChartCasting = ({ setCurrentChart, setCurrentView, darkMode, apiSt
         },
         override_flags_applied: requestData.ignoreRadicality ? {
           ignore_radicality: requestData.ignoreRadicality,
-          ignore_void_moon: requestData.ignoreVoidMoon,
           ignore_combustion: requestData.ignoreCombustion,
           ignore_saturn_7th: requestData.ignoreSaturn7th
         } : {}
@@ -1878,23 +1875,6 @@ const EnhancedChartCasting = ({ setCurrentChart, setCurrentView, darkMode, apiSt
                           <span className="font-medium">Override Radicality Warnings</span>
                           <div className="text-xs text-gray-500 dark:text-gray-400">
                             Remove cautions and restore full confidence
-                          </div>
-                        </div>
-                      </label>
-
-                      <label className="flex items-center space-x-3 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={advancedOptions.ignoreVoidMoon}
-                          onChange={(e) => setAdvancedOptions(prev => ({
-                            ...prev, ignoreVoidMoon: e.target.checked
-                          }))}
-                          className="w-4 h-4 text-indigo-600 focus:ring-indigo-500 rounded"
-                        />
-                        <div>
-                          <span className="font-medium">Override Void Moon Warnings</span>
-                          <div className="text-xs text-gray-500 dark:text-gray-400">
-                            Proceed with full confidence despite void status
                           </div>
                         </div>
                       </label>
@@ -2357,9 +2337,6 @@ const EnhancedJudgmentPanel = ({ chart, darkMode }) => {
               <div className="text-xs text-blue-700 dark:text-blue-300 space-y-1">
                 {overrideFlags.ignore_radicality && (
                   <div>• Radicality check bypassed - judgment proceeded despite traditional concerns</div>
-                )}
-                {overrideFlags.ignore_void_moon && (
-                  <div>• Void Moon restriction bypassed - judgment given despite Moon's condition</div>
                 )}
                 {overrideFlags.ignore_combustion && (
                   <div>• Solar combustion effects ignored - planets treated as free from solar interference</div>


### PR DESCRIPTION
## Summary
- drop `ignoreVoidMoon` option from frontend form and payload
- eliminate `ignore_void_moon` parameter in API and horary engine
- always compute and record void-of-course Moon checks
- update example charts to match new override flags
- sanitize log strings to avoid Unicode errors with non-ASCII location or question names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5942e2a74832489f74abd71914618