### PR TITLE
Handle loan application questions in analyzer

### DIFF
--- a/codexhorary1/backend/question_analyzer.py
+++ b/codexhorary1/backend/question_analyzer.py
@@ -38,8 +38,8 @@ class TraditionalHoraryQuestionAnalyzer:
             Category.CHILDREN: ["child", "children", "son", "daughter", "offspring", "kids"],
             Category.TRAVEL: ["journey", "travel", "trip", "go to", "visit", "vacation", "move to"],
             Category.GAMBLING: ["lottery", "lotto", "win lottery", "jackpot", "scratch", "raffle", "betting", "bet", "gamble", "gambling", "casino", "poker", "blackjack", "slots", "dice", "win money", "lucky", "speculation"],
-            Category.FUNDING: ["funding", "fund", "investment", "invest", "investor", "funding round", "seed", "series a", "series b", "venture capital", "vc", "angel", "capital", "raise money", "raise capital", "secure funding", "startup funding", "business loan", "finance", "financial backing", "sponsor", "grant", "equity", "valuation"],
-            Category.MONEY: ["money", "wealth", "rich", "profit", "gain", "debt", "financial", "income", "salary", "pay", "trading", "stock"],
+            Category.FUNDING: ["funding", "fund", "investment", "invest", "investor", "funding round", "seed", "series a", "series b", "venture capital", "vc", "angel", "capital", "raise money", "raise capital", "secure funding", "startup funding", "business loan", "loan", "loan application", "finance", "financial backing", "sponsor", "grant", "equity", "valuation"],
+            Category.MONEY: ["money", "wealth", "rich", "profit", "gain", "debt", "financial", "income", "salary", "pay", "trading", "stock", "loan", "loan application"],
             Category.CAREER: ["job", "career", "work", "employment", "business", "promotion", "interview"],
             Category.HEALTH: ["sick", "illness", "disease", "health", "recover", "die", "cure", "healing", "medical"],
             Category.LAWSUIT: ["court", "lawsuit", "legal", "judge", "trial", "litigation", "case"],
@@ -398,7 +398,7 @@ class TraditionalHoraryQuestionAnalyzer:
         """Enhanced question type determination with transaction and possession priority"""
         
         # PRIORITY 1: Financial transactions override relationship keywords
-        transaction_words = ["sell", "buy", "purchase", "sale", "profit", "gain", "lose", "cost", "price", "payment", "trade", "exchange"]
+        transaction_words = ["sell", "buy", "purchase", "sale", "profit", "gain", "lose", "cost", "price", "payment", "trade", "exchange", "loan"]
         if any(word in question for word in transaction_words):
             return Category.MONEY, [word for word in transaction_words if word in question]
         

--- a/codexhorary1/backend/tests/test_question_analyzer.py
+++ b/codexhorary1/backend/tests/test_question_analyzer.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from question_analyzer import TraditionalHoraryQuestionAnalyzer
+from taxonomy import Category
+
+
+def test_loan_application_question():
+    analyzer = TraditionalHoraryQuestionAnalyzer()
+    question = "Will my loan application be approved?"
+    question_lower = question.lower()
+    q_type, _ = analyzer._determine_question_type(question_lower)
+    assert q_type in {Category.FUNDING, Category.MONEY}
+    houses, _ = analyzer._determine_houses(question_lower, q_type, None)
+    assert houses in ([1, 8], [1, 2])
+


### PR DESCRIPTION
## Summary
- recognize loans and loan applications as money/funding questions
- ensure transaction classifier handles loan keywords
- add regression test for loan application question

## Testing
- `pytest backend/tests/test_question_analyzer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f7dbc7d08324bd8ad8388201bc1f