### PR TITLE
Refactor weight handling in reasoning UI

### DIFF
--- a/codexhorary1/frontend/QA.md
+++ b/codexhorary1/frontend/QA.md
@@ -1,0 +1,15 @@
+# Manual QA for weight parsing
+
+Use these steps to verify weight handling in the reasoning list.
+
+1. Launch the frontend with `npm run dev`.
+2. Submit a chart with a reasoning array such as:
+   ```
+   [
+     "Positive factor (+1)",
+     "Negative factor (-2)",
+     "Neutral note"
+   ]
+   ```
+3. Confirm the UI renders a green dot for the first item, a red dot for the second, and an amber dot for the third.
+4. Repeat with reasoning objects that already contain numeric `weight` and `stage` fields to ensure they are used directly.


### PR DESCRIPTION
## Summary
- Parse explicit (+/-n) weight hints when backend doesn't provide structured data
- Simplify color logic to use numeric weights only
- Document manual QA steps for positive, negative and neutral weights

## Testing
- `npm test` *(fails: Cannot find module 'tests/buildChartPayload.test.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68a5fec8ef7c8324936e24cf504c0c7d