### PR TITLE
Constrain reasoning weight parsing to explicit trailing tokens

### DIFF
--- a/codexhorary1/frontend/src/utils/parseReasoning.mjs
+++ b/codexhorary1/frontend/src/utils/parseReasoning.mjs
@@ -2,30 +2,13 @@ export function parseReasoningEntry(text) {
   if (typeof text !== 'string') {
     return { rule: '', weight: 0 };
   }
-  const matches = [...text.matchAll(/[-+]?\d+%?/g)];
-  if (matches.length === 0) {
-    return { rule: text.trim(), weight: 0 };
+  const parenMatch = text.match(/\(([-+]?\d+)\s*%?\)\s*$/);
+  if (parenMatch) {
+    return { rule: text.slice(0, parenMatch.index).trim(), weight: parseInt(parenMatch[1], 10) || 0 };
   }
-  const last = matches[matches.length - 1];
-  const token = last[0];
-  let weight = parseInt(token, 10) || 0;
-  let start = last.index;
-  let end = start + token.length;
-
-  let before = text.slice(0, start);
-  let after = text.slice(end);
-
-  const beforeParen = before.match(/\(\s*$/);
-  const afterParen = after.match(/^\s*\)/);
-  if (beforeParen && afterParen) {
-    start -= beforeParen[0].length;
-    end += afterParen[0].length;
-    before = text.slice(0, start);
-    after = text.slice(end);
+  const signedMatch = text.match(/([-+]\d+)\s*%?\s*$/);
+  if (signedMatch) {
+    return { rule: text.slice(0, signedMatch.index).trim(), weight: parseInt(signedMatch[1], 10) || 0 };
   }
-
-  before = before.replace(/\s+$/, '');
-  after = after.replace(/^\s+/, '');
-  const rule = `${before}${before && after ? ' ' : ''}${after}`.trim();
-  return { rule, weight };
+  return { rule: text.trim(), weight: 0 };
 }

--- a/codexhorary1/frontend/tests/parseReasoning.test.mjs
+++ b/codexhorary1/frontend/tests/parseReasoning.test.mjs
@@ -29,3 +29,9 @@ test('uses last numeric token when multiple present', () => {
   assert.strictEqual(weight, -4);
   assert.strictEqual(rule, 'Mixed signals (+3)');
 });
+
+test('ignores numeric references embedded in text', () => {
+  const { rule, weight } = parseReasoningEntry('Ruler of 7');
+  assert.strictEqual(weight, 0);
+  assert.strictEqual(rule, 'Ruler of 7');
+});


### PR DESCRIPTION
## Summary
- restrict reasoning weight extraction to trailing signed or parenthesized numbers
- add regression test to ignore descriptive numerals in rule text

## Testing
- `node frontend/tests/parseReasoning.test.mjs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62149a16083249b280135830e92fc