### PR TITLE
Parse reasoning stage and weight tokens

### DIFF
--- a/codexhorary1/backend/tests/test_reasoning_structuring.py
+++ b/codexhorary1/backend/tests/test_reasoning_structuring.py
@@ -1,0 +1,15 @@
+import pytest
+
+from horary_engine.engine import _structure_reasoning
+
+
+def test_structure_reasoning_parses_stage_and_weight():
+    text = "Significators: Querent gains favor (+12%)"
+    result = _structure_reasoning([text])
+    assert result == [{"stage": "Significators", "rule": "Querent gains favor", "weight": 12}]
+
+
+def test_structure_reasoning_defaults_when_missing():
+    text = "A general observation without extra info"
+    result = _structure_reasoning([text])
+    assert result == [{"stage": "General", "rule": text, "weight": 0}]


### PR DESCRIPTION
## Summary
- extract leading stage labels and trailing weight tokens from reasoning strings
- default reasoning stage to `General` and weight to 0 when absent
- add tests covering reasoning structuring

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a669fed3488324a9ee18186a2dded1