### PR TITLE
Extend education keyword coverage

### DIFF
--- a/codexhorary1/backend/question_analyzer.py
+++ b/codexhorary1/backend/question_analyzer.py
@@ -45,7 +45,9 @@ class TraditionalHoraryQuestionAnalyzer:
             Category.LAWSUIT: ["court", "lawsuit", "legal", "judge", "trial", "litigation", "case"],
             Category.RELATIONSHIP: ["love", "relationship", "friend", "enemy", "romance", "dating", "go out", "go out with", "date", "ask out", "see each other", "like me", "interested in", "attracted to", "reconciliation", "reconcile", "get back together", "ex", "former", "past relationship", "breakup", "break up", "makeup", "make up", "together", "couple", "partner", "boyfriend", "girlfriend", "romantic", "crush", "feelings", "attraction"],
             # NEW: Education and learning patterns
-            Category.EDUCATION: ["exam", "test", "study", "student", "school", "college", "university", "learn", "pass", "graduate", "degree", "education", "academic", "course", "class", "conference", "paper", "publication", "publish", "journal", "research", "submit", "accepted", "peer review", "review", "presentation", "symposium", "seminar", "physiotherapy", "nursing", "medical", "certification"],
+            Category.EDUCATION: [
+                "exam", "test", "study", "student", "school", "college", "university", "learn", "pass", "graduate", "degree", "education", "academic", "course", "class", "conference", "paper", "publication", "publish", "journal", "research", "submit", "accepted", "peer review", "review", "presentation", "symposium", "seminar", "physiotherapy", "nursing", "medical", "certification", "admission", "admit", "admitted", "enroll", "enrolled", "enrollment", "program", "master", "masters"
+            ],
             # NEW: Specific person relationship patterns
             Category.PARENT: ["father", "mother", "dad", "mom", "parent", "stepfather", "stepmother"],
             Category.SIBLING: ["brother", "sister", "sibling"],

--- a/codexhorary1/backend/tests/test_question_analyzer.py
+++ b/codexhorary1/backend/tests/test_question_analyzer.py
@@ -18,3 +18,13 @@ def test_loan_application_question():
     houses, _ = analyzer._determine_houses(question_lower, q_type, None)
     assert houses in ([1, 8], [1, 2])
 
+
+def test_masters_program_admission_question():
+    analyzer = TraditionalHoraryQuestionAnalyzer()
+    question = "Will I be admitted to the master's program this cycle?"
+    question_lower = question.lower()
+    q_type, _ = analyzer._determine_question_type(question_lower)
+    assert q_type is Category.EDUCATION
+    houses, _ = analyzer._determine_houses(question_lower, q_type, None)
+    assert houses == [1, 10, 9]
+


### PR DESCRIPTION
## Summary
- include admission, enrollment, program, and masters terms in education keyword patterns
- add regression test covering master's program admission question
- preserve original education keywords while appending new ones

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml'; ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68a671c996848324a947bf91ed9cbcb4