### PR TITLE
Compute aspect separation via relative speed

### DIFF
--- a/codexhorary1/backend/tests/test_translation_of_light.py
+++ b/codexhorary1/backend/tests/test_translation_of_light.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.calculation.helpers import check_aspect_separation_order
+
+
+def test_separating_orb_uses_relative_speed():
+    # Planet C is ahead and moving faster than A -> separating
+    res = check_aspect_separation_order(10.0, 1.0, 12.0, 3.0, 0.0, 0.0)
+    assert res["is_separating"] is True
+    assert res["orb_rate"] > 0
+    assert res["current_orb"] == pytest.approx(2.0)
+
+
+def test_applying_when_a_catches_up():
+    # Planet C is ahead but slower than A -> applying
+    res = check_aspect_separation_order(10.0, 3.0, 12.0, 1.0, 0.0, 0.0)
+    assert res["is_separating"] is False
+    assert res["orb_rate"] < 0
+
+
+def test_handles_extremely_slow_motion():
+    # Very slow relative motion still yields correct sign
+    res = check_aspect_separation_order(0.0, 0.0, 0.1, 0.001, 0.0, 0.0)
+    assert res["is_separating"] is True
+    assert res["orb_rate"] > 0


### PR DESCRIPTION
## Summary
- compute aspect separation using relative speed and analytic orb rate
- add translation-of-light tests to verify separation calculation for various speeds

## Testing
- `pytest backend/tests/test_translation_of_light.py backend/tests/test_moon_last_aspect.py backend/tests/test_aspect_timing.py backend/tests/test_benefic_separating.py backend/tests/test_prohibition.py backend/tests/test_cross_sign.py backend/tests/test_question_analyzer.py backend/tests/test_reasoning_structuring.py backend/tests/test_reception_serialization.py backend/tests/test_taxonomy.py backend/tests/test_scoring_calibration.py backend/tests/test_voc_regression.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a675a339948324a80c137bbe317317