### PR TITLE
Fix relationship house selection

### DIFF
--- a/codexhorary1/backend/question_analyzer.py
+++ b/codexhorary1/backend/question_analyzer.py
@@ -484,7 +484,7 @@ class TraditionalHoraryQuestionAnalyzer:
 
         elif question_type == Category.RELATIONSHIP:
             # ENHANCED: Relationship questions use L1/L7 axis (self vs others)
-            houses.extend([1, 7])  # L1 = self, L7 = other person/partner
+            houses.append(7)  # L1 = self, L7 = other person/partner
 
         elif question_type == Category.PREGNANCY:
             if third_person_analysis and third_person_analysis.get("is_third_person"):

--- a/codexhorary1/backend/tests/test_question_analyzer.py
+++ b/codexhorary1/backend/tests/test_question_analyzer.py
@@ -28,3 +28,13 @@ def test_masters_program_admission_question():
     houses, _ = analyzer._determine_houses(question_lower, q_type, None)
     assert houses == [1, 10, 9]
 
+
+def test_relationship_houses():
+    analyzer = TraditionalHoraryQuestionAnalyzer()
+    question = "Does my partner love me?"
+    question_lower = question.lower()
+    q_type, _ = analyzer._determine_question_type(question_lower)
+    assert q_type is Category.RELATIONSHIP
+    houses, _ = analyzer._determine_houses(question_lower, q_type, None)
+    assert houses == [1, 7]
+

--- a/codexhorary1/backend/tests/test_taxonomy.py
+++ b/codexhorary1/backend/tests/test_taxonomy.py
@@ -66,3 +66,10 @@ def test_manual_houses_override():
     assert result["querent_house"] == 1
     assert result["quesited_house"] == 5
     assert result["quesited"] == Planet.MARS
+
+
+def test_shared_ruler_description():
+    chart = DummyChart()
+    chart.house_rulers[7] = chart.house_rulers[1]
+    result = resolve(chart, Category.RELATIONSHIP, manual_houses=[1, 7])
+    assert result["description"] == "Shared Significator: Sun rules both houses 1 and 7"


### PR DESCRIPTION
## Summary
- Avoid duplicating the 1st house for relationship questions and correctly include the 7th house
- Add tests for relationship house derivation and shared ruler description

## Testing
- `pytest codexhorary1/backend/tests/test_question_analyzer.py codexhorary1/backend/tests/test_taxonomy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a679568f10832498b9575a8a8de952