### PR TITLE
Handle chart export anchor cleanup

### DIFF
--- a/codexhorary1/frontend/src/App.jsx
+++ b/codexhorary1/frontend/src/App.jsx
@@ -1883,7 +1883,9 @@ const EnhancedChartView = ({ chart, darkMode, notes, setNotes }) => {
     const a = document.createElement('a');
     a.href = url;
     a.download = `enhanced-horary-chart-${chart.id}.json`;
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
   };
 


### PR DESCRIPTION
## Summary
- Append export anchor to the DOM, trigger click, then remove it
- Keep object URL cleanup after anchor removal

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a67b0f3b808324a2cb2d022b93bba5