### PR TITLE
Add solar aggregator with role importance scaling

### DIFF
--- a/codexhorary1/backend/evaluate_chart.py
+++ b/codexhorary1/backend/evaluate_chart.py
@@ -9,9 +9,10 @@ import sys
 # Ensure repository root on path when executed directly
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from horary_config import cfg
+
 from .category_router import get_contract
 from .horary_engine.engine import extract_testimonies
-from .horary_engine.aggregator import aggregate
 from .horary_engine.rationale import build_rationale
 from .horary_engine.utils import token_to_string
 
@@ -30,7 +31,14 @@ def evaluate_chart(chart: Dict[str, Any]) -> Dict[str, Any]:
     """
     contract = get_contract(chart.get("category", ""))
     testimonies = extract_testimonies(chart, contract)
-    score, ledger = aggregate(testimonies)
+
+    use_dsl = cfg().get("aggregator.use_dsl", False)
+    if use_dsl:
+        from .horary_engine.solar_aggregator import aggregate as aggregator_fn
+    else:
+        from .horary_engine.aggregator import aggregate as aggregator_fn
+
+    score, ledger = aggregator_fn(testimonies)
     # Surface ledger details for downstream inspection and debugging
     logger.info(
         "Contribution ledger: %s",

--- a/codexhorary1/backend/horary_constants.yaml
+++ b/codexhorary1/backend/horary_constants.yaml
@@ -1,6 +1,9 @@
 # Horary Astrology Engine Configuration
 # All timing, orbs, and confidence values for traditional horary judgment
 
+aggregator:
+  use_dsl: false
+
 timing:
   # Timing calculation parameters
   default_moon_speed_fallback: 13.0  # degrees per day (only if ephemeris fails)

--- a/codexhorary1/backend/horary_engine/solar_aggregator.py
+++ b/codexhorary1/backend/horary_engine/solar_aggregator.py
@@ -1,0 +1,93 @@
+"""Aggregate testimonies with role importance scaling."""
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple, Dict, Sequence
+
+from .polarity_weights import (
+    POLARITY_TABLE,
+    WEIGHT_TABLE,
+    FAMILY_TABLE,
+    KIND_TABLE,
+    TestimonyKey,
+)
+from .polarity import Polarity
+from .dsl import RoleImportance
+
+
+def _coerce(testimonies: Iterable[TestimonyKey | str | RoleImportance]) -> Tuple[Sequence[TestimonyKey], Dict[str, float]]:
+    """Split testimonies into tokens and role importance mapping."""
+    tokens: List[TestimonyKey] = []
+    role_weights: Dict[str, float] = {}
+    for raw in testimonies:
+        if isinstance(raw, RoleImportance):
+            role_weights[raw.role.name.lower()] = raw.importance
+            continue
+        if isinstance(raw, TestimonyKey):
+            tokens.append(raw)
+            continue
+        try:
+            tokens.append(TestimonyKey(raw))
+        except ValueError:
+            continue
+    return tokens, role_weights
+
+
+def aggregate(
+    testimonies: Iterable[TestimonyKey | str | RoleImportance],
+) -> Tuple[float, List[Dict[str, float | TestimonyKey | Polarity | str | bool]]]:
+    """Aggregate testimony tokens into a score with role importance weighting."""
+    tokens, role_weights = _coerce(testimonies)
+
+    total_yes = 0.0
+    total_no = 0.0
+    ledger: List[Dict[str, float | TestimonyKey | Polarity | str | bool]] = []
+    seen: set[TestimonyKey] = set()
+    families_seen: set[str] = set()
+
+    for token in sorted(tokens, key=lambda t: t.value):
+        if token in seen:
+            continue
+        seen.add(token)
+
+        polarity = POLARITY_TABLE.get(token, Polarity.NEUTRAL)
+        if polarity is Polarity.NEUTRAL:
+            continue
+
+        family = FAMILY_TABLE.get(token)
+        kind = KIND_TABLE.get(token)
+        context_only = family is not None and family in families_seen
+        if family is not None and not context_only:
+            families_seen.add(family)
+
+        weight = WEIGHT_TABLE.get(token, 0.0)
+
+        role_factor = 1.0
+        token_name = token.value.lower()
+        for role_name, factor in role_weights.items():
+            if role_name in token_name:
+                role_factor *= factor
+        weight *= role_factor
+
+        if weight < 0:
+            raise ValueError("Weights must be non-negative for monotonicity")
+
+        delta_yes = weight if (not context_only and polarity is Polarity.POSITIVE) else 0.0
+        delta_no = weight if (not context_only and polarity is Polarity.NEGATIVE) else 0.0
+        total_yes += delta_yes
+        total_no += delta_no
+        ledger.append(
+            {
+                "key": token,
+                "polarity": polarity,
+                "weight": weight,
+                "delta_yes": delta_yes,
+                "delta_no": delta_no,
+                "family": family,
+                "kind": kind,
+                "context": context_only,
+                "role_factor": role_factor,
+            }
+        )
+
+    total = total_yes - total_no
+    return total, ledger

--- a/codexhorary1/backend/tests/test_solar_aggregator.py
+++ b/codexhorary1/backend/tests/test_solar_aggregator.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.dsl import role_importance, Moon
+from horary_engine.polarity_weights import TestimonyKey
+from horary_engine.solar_aggregator import aggregate as solar_aggregate
+from horary_engine.aggregator import aggregate as legacy_aggregate
+
+
+def test_role_importance_scales_weights():
+    testimonies = [
+        role_importance(Moon, 0.7),
+        TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
+    ]
+    score, ledger = solar_aggregate(testimonies)
+    assert score == 0.7
+    assert ledger[0]["weight"] == 0.7
+
+
+def test_legacy_and_solar_equal_without_importance():
+    tokens = [TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN]
+    score_legacy, _ = legacy_aggregate(tokens)
+    score_solar, _ = solar_aggregate(tokens)
+    assert score_legacy == score_solar
+
+
+def test_solar_scales_relative_to_legacy():
+    tokens = [TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN]
+    score_legacy, _ = legacy_aggregate(tokens)
+    score_solar, _ = solar_aggregate([
+        role_importance(Moon, 0.5),
+        TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
+    ])
+    assert score_solar == score_legacy * 0.5


### PR DESCRIPTION
## Summary
- add solar aggregator that scales testimony weights by role importance
- allow configuration to toggle between legacy and DSL aggregators
- cover solar aggregator with tests

## Testing
- `cd codexhorary1/backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a68b9f34cc832492bacf01ac51d115