### PR TITLE
Load Lilly rule pack via YAML and add rule engine tests

### DIFF
--- a/codexhorary1/backend/rule_dump.py
+++ b/codexhorary1/backend/rule_dump.py
@@ -1,35 +1,13 @@
 from typing import Any, Dict, List
 
-import rules
-
-
-def _resolve_weight(rule: Dict[str, Any]) -> float:
-    """Resolve the weight for a rule."""
-    if isinstance(rule.get("weight"), (int, float)):
-        return float(rule["weight"])
-
-    fn_name = rule.get("weight_fn")
-    if fn_name:
-        fn = getattr(rules, fn_name, None)
-        if callable(fn):
-            return float(fn())
-        raise ValueError(f"Weight function '{fn_name}' not found")
-
-    raise ValueError(f"Rule '{rule.get('id')}' lacks a weight or weight_fn")
+from rule_engine import RULES, get_rule_weight
 
 
 def dump_rules() -> List[Dict[str, Any]]:
-    """Return a list of rules with resolved numeric weights."""
-    dumped: List[Dict[str, Any]] = []
-    for rule in rules.RULES:
-        weight = _resolve_weight(rule)
-        dumped.append({**{k: v for k, v in rule.items() if k != "weight_fn"}, "weight": weight})
-    return dumped
+    """Return a list of loaded rules with numeric weights."""
+    return RULES
 
 
 def apply_rule(rule_id: str, value: float) -> float:
     """Apply a rule's weight to a value."""
-    for rule in dump_rules():
-        if rule.get("id") == rule_id:
-            return value * rule["weight"]
-    raise KeyError(f"Unknown rule id: {rule_id}")
+    return value * get_rule_weight(rule_id)

--- a/codexhorary1/backend/rule_engine.py
+++ b/codexhorary1/backend/rule_engine.py
@@ -1,9 +1,26 @@
 """Rule evaluation utilities implementing tiered priority with first-hit wins."""
 from __future__ import annotations
 
-from typing import Iterable, List
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
 
-import rules
+import yaml
+
+
+# Default rule pack selection
+RULE_PACK = "lilly_general_v1"
+
+
+def load_rules(pack: str = RULE_PACK) -> List[Dict[str, Any]]:
+    """Load rule definitions from a YAML rule pack."""
+    path = Path(__file__).with_name(f"rules_{pack}.yaml")
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("rules", [])
+
+
+# Loaded rule set used throughout the module
+RULES = load_rules()
 
 # Fixed priority order for rule tiers
 PRIORITY_TIERS = [
@@ -37,7 +54,7 @@ def evaluate_rules(candidate_ids: Iterable[str]) -> List[str]:
     selected: List[str] = []
     for tier in PRIORITY_TIERS:
         tier_rules = sorted(
-            (r for r in rules.RULES if r.get("tier") == tier),
+            (r for r in RULES if r.get("tier") == tier),
             key=lambda r: r["id"],
         )
         for rule in tier_rules:
@@ -48,3 +65,19 @@ def evaluate_rules(candidate_ids: Iterable[str]) -> List[str]:
                 selected.append(rule["id"])
                 break  # first-hit wins within tier
     return selected
+
+
+def get_rule_weight(rule_id: str) -> float:
+    """Return the numeric weight for a rule ID."""
+    for rule in RULES:
+        if rule.get("id") == rule_id:
+            weight = rule.get("weight")
+            if isinstance(weight, (int, float)):
+                return float(weight)
+            raise ValueError(f"Rule '{rule_id}' lacks a numeric weight")
+    raise KeyError(f"Unknown rule id: {rule_id}")
+
+
+def apply_rule(rule_id: str, value: float) -> float:
+    """Apply a rule's weight to a value."""
+    return value * get_rule_weight(rule_id)

--- a/codexhorary1/backend/rules_lilly_general_v1.yaml
+++ b/codexhorary1/backend/rules_lilly_general_v1.yaml
@@ -1,0 +1,57 @@
+rules:
+  - id: V1
+    tier: validity_gates
+    description: Early Ascendant
+    weight: -2.0
+  - id: V2
+    tier: validity_gates
+    description: Late Ascendant
+    weight: -2.0
+  - id: H1
+    tier: hard_stoppers
+    description: Saturn in 7th
+    weight: -3.0
+  - id: H2
+    tier: hard_stoppers
+    description: Void of Course
+    weight: -3.0
+  - id: P1
+    tier: perfection
+    description: Direct perfection
+    weight: 2.0
+  - id: P2
+    tier: perfection
+    description: Translation of light
+    weight: 2.0
+  - id: S1
+    tier: special_topics
+    description: Education overrides
+    weight: 1.5
+  - id: S2
+    tier: special_topics
+    description: Medical exceptions
+    weight: 1.5
+  - id: M1
+    tier: moon
+    description: Moon trine Sun
+    weight: 1.8
+  - id: M2
+    tier: moon
+    description: Moon square Saturn
+    weight: -2.2
+  - id: MOD1
+    tier: modifiers
+    description: Reception boost
+    weight: 1.2
+  - id: MOD2
+    tier: modifiers
+    description: Debility penalty
+    weight: -1.5
+  - id: T1
+    tier: thresholds
+    description: Dignity threshold
+    weight: 1.0
+  - id: T2
+    tier: thresholds
+    description: Speed threshold
+    weight: -1.0

--- a/codexhorary1/backend/tests/test_rule_engine.py
+++ b/codexhorary1/backend/tests/test_rule_engine.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from rule_engine import evaluate_rules, get_rule_weight, apply_rule
+
+
+def test_rule_sequencing():
+    candidates = ["V1", "H1", "P1", "M1", "MOD2", "T1"]
+    assert evaluate_rules(candidates) == ["V1", "H1", "P1", "M1", "MOD2", "T1"]
+
+
+def test_weight_application():
+    assert get_rule_weight("H1") == -3.0
+    assert apply_rule("P1", 5.0) == 10.0


### PR DESCRIPTION
## Summary
- load `rules_lilly_general_v1` YAML rule pack and expose helper functions for weights
- simplify rule dump to use loaded rules
- add tests validating rule sequencing and weight application

## Testing
- `pytest codexhorary1/backend/tests/test_rule_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a68f3ba9988324a7e900e90dc8bdd0