### PR TITLE
Enable DSL aggregation by default with runtime toggles

### DIFF
--- a/codexhorary1/backend/README.md
+++ b/codexhorary1/backend/README.md
@@ -5,3 +5,12 @@ question categories and their defaults. Modules such as
 `question_analyzer`, `category_router` and the horary engine import the
 `Category` enum instead of hard coded strings. Legacy string values are
 still accepted but will emit a warning.
+
+## Aggregation modes
+
+The engine ships with a new DSL-based aggregation system enabled by
+default. To revert to the legacy aggregator without editing
+configuration files, set the `HORARY_USE_DSL` environment variable to
+`false`. The `evaluate_chart` function also accepts a `use_dsl` argument
+which callers can populate from a query parameter or HTTP header to
+switch modes dynamically.

--- a/codexhorary1/backend/horary_constants.yaml
+++ b/codexhorary1/backend/horary_constants.yaml
@@ -2,7 +2,10 @@
 # All timing, orbs, and confidence values for traditional horary judgment
 
 aggregator:
-  use_dsl: false
+  # Defaults to the new DSL-based aggregator. Set the HORARY_USE_DSL
+  # environment variable to "false" to fall back to the legacy aggregation
+  # logic without editing this file.
+  use_dsl: true
 
 timing:
   # Timing calculation parameters


### PR DESCRIPTION
## Summary
- Default backend to the new DSL-based aggregation
- Allow overriding aggregation via `HORARY_USE_DSL` env var or `use_dsl` argument to `evaluate_chart`
- Document runtime switching in backend README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a69a23c32483248bcda3b8d37de8d2