### PR TITLE
refactor: extract cleanMoonText utility

### DIFF
--- a/codexhorary1/frontend/src/App.jsx
+++ b/codexhorary1/frontend/src/App.jsx
@@ -1,23 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { buildChartPayload } from './utils/buildChartPayload';
 import { parseReasoningEntry } from './utils/parseReasoning.mjs';
-
-// Text cleanup utility for removing duplicate Moon references and parentheticals
-const cleanMoonText = (text) => {
-  if (!text || typeof text !== 'string') return text;
-  
-  return text
-    // Remove duplicate "Moon" references
-    .replace(/Void(?: ☽)? Moon:\s*(?:☽\s*)?Moon/gi, 'Void Moon:')
-    .replace(/☽ Moon/g, 'Moon')
-    .replace(/Moon Moon/g, 'Moon')
-    // Remove trailing parentheticals like "(moon)"
-    .replace(/\s*\([^)]*moon[^)]*\)\s*$/gi, '')
-    // Clean up spacing and punctuation
-    .replace(/:\s+makes/g, ': makes')
-    .replace(/\s+/g, ' ')
-    .trim();
-};
+import { cleanMoonText } from './utils/cleanMoonText';
 
 import { 
   Calendar, 

--- a/codexhorary1/frontend/src/utils/buildChartPayload.js
+++ b/codexhorary1/frontend/src/utils/buildChartPayload.js
@@ -1,19 +1,4 @@
-// Text cleanup utility for removing duplicate Moon references and parentheticals
-const cleanMoonText = (text) => {
-  if (!text || typeof text !== 'string') return text;
-  
-  return text
-    // Remove duplicate "Moon" references
-    .replace(/Void(?: ☽)? Moon:\s*(?:☽\s*)?Moon/gi, 'Void Moon:')
-    .replace(/☽ Moon/g, 'Moon')
-    .replace(/Moon Moon/g, 'Moon')
-    // Remove trailing parentheticals like "(moon)"
-    .replace(/\s*\([^)]*moon[^)]*\)\s*$/gi, '')
-    // Clean up spacing and punctuation
-    .replace(/:\s+makes/g, ': makes')
-    .replace(/\s+/g, ' ')
-    .trim();
-};
+import { cleanMoonText } from './cleanMoonText';
 
 export function buildChartPayload(chart, includeVerdict = true) {
   const utcTime = chart?.chart_data?.timezone_info?.utc_time;

--- a/codexhorary1/frontend/src/utils/cleanMoonText.js
+++ b/codexhorary1/frontend/src/utils/cleanMoonText.js
@@ -1,0 +1,16 @@
+// Text cleanup utility for removing duplicate Moon references and parentheticals
+export const cleanMoonText = (text) => {
+  if (!text || typeof text !== 'string') return text;
+
+  return text
+    // Remove duplicate "Moon" references
+    .replace(/Void(?: ☽)? Moon:\s*(?:☽\s*)?Moon/gi, 'Void Moon:')
+    .replace(/☽ Moon/g, 'Moon')
+    .replace(/Moon Moon/g, 'Moon')
+    // Remove trailing parentheticals like "(moon)"
+    .replace(/\s*\([^)]*moon[^)]*\)\s*$/gi, '')
+    // Clean up spacing and punctuation
+    .replace(/:\s+makes/g, ': makes')
+    .replace(/\s+/g, ' ')
+    .trim();
+};


### PR DESCRIPTION
## Summary
- extract `cleanMoonText` into `src/utils/cleanMoonText.js`
- reuse `cleanMoonText` in `App.jsx` and `buildChartPayload.js`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a0f53ef8832485593266b0cbacdc