### PR TITLE
Use regex role matching in solar aggregator

### DIFF
--- a/codexhorary1/backend/horary_engine/polarity_weights.py
+++ b/codexhorary1/backend/horary_engine/polarity_weights.py
@@ -12,6 +12,7 @@ class TestimonyKey(Enum):
 
     MOON_APPLYING_TRINE_EXAMINER_SUN = "moon_applying_trine_examiner_sun"
     MOON_APPLYING_SQUARE_EXAMINER_SUN = "moon_applying_square_examiner_sun"
+    L10_FORTUNATE = "l10_fortunate"
     PERFECTION_DIRECT = "perfection_direct"
     PERFECTION_TRANSLATION_OF_LIGHT = "perfection_translation_of_light"
     PERFECTION_COLLECTION_OF_LIGHT = "perfection_collection_of_light"
@@ -26,6 +27,8 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: Polarity.POSITIVE,
     # Example negative testimony
     TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: Polarity.NEGATIVE,
+    # Fortunate outcome promised by L10
+    TestimonyKey.L10_FORTUNATE: Polarity.POSITIVE,
     # Perfection testimonies are positive by default
     TestimonyKey.PERFECTION_DIRECT: Polarity.POSITIVE,
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: Polarity.POSITIVE,
@@ -35,6 +38,7 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
 WEIGHT_TABLE: dict[TestimonyKey, float] = {
     TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: 1.0,
     TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: 1.0,
+    TestimonyKey.L10_FORTUNATE: 1.0,
     TestimonyKey.PERFECTION_DIRECT: 1.0,
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: 1.0,
     TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: 1.0,

--- a/codexhorary1/backend/horary_engine/solar_aggregator.py
+++ b/codexhorary1/backend/horary_engine/solar_aggregator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Iterable, List, Tuple, Dict, Sequence
+import re
 
 from .polarity_weights import (
     POLARITY_TABLE,
@@ -64,7 +65,8 @@ def aggregate(
         role_factor = 1.0
         token_name = token.value.lower()
         for role_name, factor in role_weights.items():
-            if role_name in token_name:
+            pattern = rf"(^|_){re.escape(role_name)}_"
+            if re.search(pattern, token_name):
                 role_factor *= factor
         weight *= role_factor
 

--- a/codexhorary1/backend/tests/test_solar_aggregator.py
+++ b/codexhorary1/backend/tests/test_solar_aggregator.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-from horary_engine.dsl import role_importance, Moon
+from horary_engine.dsl import role_importance, Moon, L1, L10
 from horary_engine.polarity_weights import TestimonyKey
 from horary_engine.solar_aggregator import aggregate as solar_aggregate
 from horary_engine.aggregator import aggregate as legacy_aggregate
@@ -36,3 +36,14 @@ def test_solar_scales_relative_to_legacy():
         TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
     ])
     assert score_solar == score_legacy * 0.5
+
+
+def test_role_matching_uses_delimiters():
+    testimonies = [
+        role_importance(L1, 0.5),
+        role_importance(L10, 2.0),
+        TestimonyKey.L10_FORTUNATE,
+    ]
+    score, ledger = solar_aggregate(testimonies)
+    assert score == 2.0
+    assert ledger[0]["weight"] == 2.0


### PR DESCRIPTION
## Summary
- Avoid role overlap by matching role prefixes using regex in solar aggregator
- Add `L10_FORTUNATE` testimony key with consistent delimiters and polarity/weight entries
- Expand tests to verify role weighting relies on prefix delimiters

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6a344385c83248792379d5fb1d797