### PR TITLE
Restrict timed perfections to applying in-orb contacts

### DIFF
--- a/codexhorary1/backend/horary_constants.yaml
+++ b/codexhorary1/backend/horary_constants.yaml
@@ -12,6 +12,7 @@ timing:
   default_moon_speed_fallback: 13.0  # degrees per day (only if ephemeris fails)
   timing_precision_days: 0.1  # minimum timing increment
   max_future_days: 365  # maximum days to look ahead for aspects/stations
+  max_horary_days: 30   # maximum days considered valid for horary perfection
   
   # Timeframe support
   default_window_days: 365   # Default window when no timeframe specified


### PR DESCRIPTION
## Summary
- ensure direct timed perfections only apply when significators are within moiety orb and applying
- enforce sign-boundary and horary-window limits for timed aspects, flagging distant ones as astronomical alignments
- add configuration for `timing.max_horary_days`

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6a7d69d688324ab644e877b43d4df