### PR TITLE
Emit debility tokens and weight via rule engine

### DIFF
--- a/codexhorary1/backend/horary_engine/dsl.py
+++ b/codexhorary1/backend/horary_engine/dsl.py
@@ -142,25 +142,36 @@ def reception(receiver: Actor, received: Actor, dignity: str) -> Reception:
 
 @dataclass
 class EssentialDignity:
-    """Essential dignity score for an actor."""
+    """Essential dignity indicator for an actor.
+
+    The ``score`` field traditionally stores a numeric value but in some
+    contexts we want to surface qualitative tokens (e.g. ``"detriment"``).
+    To keep the primitive flexible we allow either a ``float`` or a string
+    descriptor which higher level components may interpret as a discrete
+    debility marker.
+    """
 
     actor: Actor
-    score: float
+    score: Union[float, str]
 
 
-def essential(actor: Actor, score: float) -> EssentialDignity:
+def essential(actor: Actor, score: Union[float, str]) -> EssentialDignity:
     return EssentialDignity(actor, score)
 
 
 @dataclass
 class AccidentalDignity:
-    """Accidental dignity score for an actor."""
+    """Accidental dignity indicator for an actor.
+
+    Similar to :class:`EssentialDignity`, the ``score`` may be a number or a
+    qualitative token such as ``"retro"`` to denote retrogradation.
+    """
 
     actor: Actor
-    score: float
+    score: Union[float, str]
 
 
-def accidental(actor: Actor, score: float) -> AccidentalDignity:
+def accidental(actor: Actor, score: Union[float, str]) -> AccidentalDignity:
     return AccidentalDignity(actor, score)
 
 

--- a/codexhorary1/backend/horary_engine/engine.py
+++ b/codexhorary1/backend/horary_engine/engine.py
@@ -50,6 +50,7 @@ from .dsl import (
     prohibition as dsl_prohibition,
     reception as dsl_reception,
     essential as dsl_essential,
+    accidental as dsl_accidental,
     L1,
     LQ,
     Moon as MoonRole,
@@ -171,9 +172,13 @@ def extract_testimonies(chart: HoraryChart, contract: Dict[str, Planet]) -> List
     # Dignity states (essential)
     # ------------------------------------------------------------------
     for planet, pos in getattr(chart, "planets", {}).items():
-        primitives.append(
-            dsl_essential(resolve_actor(planet), float(pos.dignity_score))
-        )
+        actor = resolve_actor(planet)
+        primitives.append(dsl_essential(actor, float(pos.dignity_score)))
+        # Emit qualitative debility tokens for downstream rule weighting
+        if pos.dignity_score <= -5:
+            primitives.append(dsl_essential(actor, "detriment"))
+        if pos.retrograde:
+            primitives.append(dsl_accidental(actor, "retro"))
 
     # ------------------------------------------------------------------
     # Translation, collection & prohibition

--- a/codexhorary1/backend/horary_engine/polarity_weights.py
+++ b/codexhorary1/backend/horary_engine/polarity_weights.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from enum import Enum
 
 from .polarity import Polarity
+from rule_engine import get_rule_weight
 
 
 class TestimonyKey(Enum):
@@ -16,6 +17,8 @@ class TestimonyKey(Enum):
     PERFECTION_DIRECT = "perfection_direct"
     PERFECTION_TRANSLATION_OF_LIGHT = "perfection_translation_of_light"
     PERFECTION_COLLECTION_OF_LIGHT = "perfection_collection_of_light"
+    ESSENTIAL_DETRIMENT = "essential_detriment"
+    ACCIDENTAL_RETROGRADE = "accidental_retrograde"
 
 
 # Prevent pytest from collecting the enum as a test class
@@ -33,6 +36,9 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     TestimonyKey.PERFECTION_DIRECT: Polarity.POSITIVE,
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: Polarity.POSITIVE,
     TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: Polarity.POSITIVE,
+    # Debility indicators
+    TestimonyKey.ESSENTIAL_DETRIMENT: Polarity.NEGATIVE,
+    TestimonyKey.ACCIDENTAL_RETROGRADE: Polarity.NEGATIVE,
 }
 
 WEIGHT_TABLE: dict[TestimonyKey, float] = {
@@ -42,6 +48,9 @@ WEIGHT_TABLE: dict[TestimonyKey, float] = {
     TestimonyKey.PERFECTION_DIRECT: 1.0,
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: 1.0,
     TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: 1.0,
+    # Debility weights sourced from rule pack
+    TestimonyKey.ESSENTIAL_DETRIMENT: abs(get_rule_weight("MOD2")),
+    TestimonyKey.ACCIDENTAL_RETROGRADE: abs(get_rule_weight("MOD3")),
 }
 
 

--- a/codexhorary1/backend/rules.py
+++ b/codexhorary1/backend/rules.py
@@ -34,6 +34,7 @@ RULES: List[RuleDict] = [
     {"id": "M2", "tier": "moon", "description": "Moon square Saturn", "weight": 1.0},
     {"id": "MOD1", "tier": "modifiers", "description": "Reception boost", "weight": 1.0},
     {"id": "MOD2", "tier": "modifiers", "description": "Debility penalty", "weight": 1.0},
+    {"id": "MOD3", "tier": "modifiers", "description": "Retrograde penalty", "weight": 1.0},
     {"id": "T1", "tier": "thresholds", "description": "Dignity threshold", "weight": 1.0},
     {"id": "T2", "tier": "thresholds", "description": "Speed threshold", "weight": 1.0},
 ]

--- a/codexhorary1/backend/rules_lilly_general_v1.yaml
+++ b/codexhorary1/backend/rules_lilly_general_v1.yaml
@@ -47,6 +47,10 @@ rules:
     tier: modifiers
     description: Debility penalty
     weight: -1.5
+  - id: MOD3
+    tier: modifiers
+    description: Retrograde penalty
+    weight: -1.5
   - id: T1
     tier: thresholds
     description: Dignity threshold

--- a/codexhorary1/backend/tests/test_debility_tokens.py
+++ b/codexhorary1/backend/tests/test_debility_tokens.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.polarity_weights import TestimonyKey
+from horary_engine.aggregator import aggregate
+from rule_engine import get_rule_weight
+
+
+def test_essential_detriment_penalty():
+    score, ledger = aggregate([TestimonyKey.ESSENTIAL_DETRIMENT])
+    expected = get_rule_weight("MOD2")
+    assert score == expected
+    assert ledger[0]["delta_no"] == abs(expected)
+
+
+def test_accidental_retrograde_penalty():
+    score, ledger = aggregate([TestimonyKey.ACCIDENTAL_RETROGRADE])
+    expected = get_rule_weight("MOD3")
+    assert score == expected
+    assert ledger[0]["delta_no"] == abs(expected)


### PR DESCRIPTION
## Summary
- Emit qualitative debility tokens for significators in detriment or retrograde
- Weight new debility tokens using rule pack entries and polarity tables
- Add tests ensuring detriment or retrograde planets contribute negative weight

## Testing
- `pytest backend/tests/test_debility_tokens.py -q`
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6aad970e08324905b467e54393473