### PR TITLE
Expose prohibition details for timed perfections

### DIFF
--- a/codexhorary1/backend/horary_engine/engine.py
+++ b/codexhorary1/backend/horary_engine/engine.py
@@ -3610,16 +3610,24 @@ class EnhancedTraditionalHoraryJudgmentEngine:
                     chart, querent, quesited, days_to_perfection
                 )
                 if prohibition_check.get("prohibited"):
+                    # Pass through prohibitor details so callers know what blocked perfection
                     return {
                         "perfects": False,
                         "type": prohibition_check.get("type", "prohibition"),
                         "reason": prohibition_check["reason"],
+                        "prohibitor": prohibition_check.get("prohibitor"),
+                        "significator": prohibition_check.get("significator"),
                     }
 
                 if prohibition_check.get("type") in ("translation", "collection"):
                     kind = prohibition_check["type"]
                     conf_key = (
                         "translation_of_light" if kind == "translation" else "collection_of_light"
+                    )
+                    extra = (
+                        {"translator": prohibition_check.get("translator")}
+                        if kind == "translation"
+                        else {"collector": prohibition_check.get("collector")}
                     )
                     return {
                         "perfects": True,
@@ -3629,6 +3637,7 @@ class EnhancedTraditionalHoraryJudgmentEngine:
                         "reason": prohibition_check["reason"],
                         "t_perfect_days": prohibition_check.get("t_event"),
                         "aspect": aspect_type,
+                        **extra,
                         "tags": [{"family": "perfection", "kind": kind}],
                     }
 

--- a/codexhorary1/backend/tests/test_direct_timed_pass_through.py
+++ b/codexhorary1/backend/tests/test_direct_timed_pass_through.py
@@ -1,0 +1,114 @@
+import datetime
+
+import pytest
+
+from backend.horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+from models import HoraryChart, PlanetPosition, Planet, Sign
+
+
+def _build_simple_chart():
+    now = datetime.datetime.utcnow()
+    planets = {
+        Planet.VENUS: PlanetPosition(
+            planet=Planet.VENUS,
+            longitude=0.0,
+            latitude=0.0,
+            house=1,
+            sign=Sign.ARIES,
+            dignity_score=0,
+            speed=1.0,
+        ),
+        Planet.JUPITER: PlanetPosition(
+            planet=Planet.JUPITER,
+            longitude=3.0,
+            latitude=0.0,
+            house=7,
+            sign=Sign.ARIES,
+            dignity_score=0,
+            speed=0.5,
+        ),
+    }
+    return HoraryChart(
+        date_time=now,
+        date_time_utc=now,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=[0.0] * 12,
+        house_rulers={},
+        ascendant=0.0,
+        midheaven=0.0,
+        julian_day=0.0,
+    )
+
+
+def test_passes_prohibition_details(monkeypatch):
+    chart = _build_simple_chart()
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    monkeypatch.setattr(
+        engine, "_calculate_future_aspect_time", lambda *args, **kwargs: 5
+    )
+    monkeypatch.setattr(
+        engine,
+        "_check_future_prohibitions",
+        lambda *args, **kwargs: {
+            "prohibited": True,
+            "type": "prohibition",
+            "prohibitor": Planet.SATURN,
+            "significator": Planet.VENUS,
+            "reason": "Saturn blocks Venus",
+        },
+    )
+    res = engine._check_direct_timed_perfection(chart, Planet.VENUS, Planet.JUPITER, 10)
+    assert res["perfects"] is False
+    assert res["type"] == "prohibition"
+    assert res["prohibitor"] == Planet.SATURN
+    assert res["significator"] == Planet.VENUS
+
+
+def test_passes_translation_details(monkeypatch):
+    chart = _build_simple_chart()
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    monkeypatch.setattr(
+        engine, "_calculate_future_aspect_time", lambda *args, **kwargs: 5
+    )
+    monkeypatch.setattr(
+        engine,
+        "_check_future_prohibitions",
+        lambda *args, **kwargs: {
+            "prohibited": False,
+            "type": "translation",
+            "translator": Planet.MERCURY,
+            "t_event": 2,
+            "reason": "Mercury translates light",
+        },
+    )
+    res = engine._check_direct_timed_perfection(chart, Planet.VENUS, Planet.JUPITER, 10)
+    assert res["perfects"] is True
+    assert res["type"] == "translation"
+    assert res["translator"] == Planet.MERCURY
+
+
+def test_passes_collection_details(monkeypatch):
+    chart = _build_simple_chart()
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    monkeypatch.setattr(
+        engine, "_calculate_future_aspect_time", lambda *args, **kwargs: 5
+    )
+    monkeypatch.setattr(
+        engine,
+        "_check_future_prohibitions",
+        lambda *args, **kwargs: {
+            "prohibited": False,
+            "type": "collection",
+            "collector": Planet.SATURN,
+            "t_event": 2,
+            "reason": "Saturn collects light",
+        },
+    )
+    res = engine._check_direct_timed_perfection(chart, Planet.VENUS, Planet.JUPITER, 10)
+    assert res["perfects"] is True
+    assert res["type"] == "collection"
+    assert res["collector"] == Planet.SATURN

--- a/codexhorary1/frontend/src/App.jsx
+++ b/codexhorary1/frontend/src/App.jsx
@@ -285,7 +285,31 @@ const JudgmentBreakdown = ({ reasoning, darkMode }) => {
         </a>
       );
     }
-    return renderTextWithPlanetSymbols(cleanMoonText(text));
+    const content = renderTextWithPlanetSymbols(cleanMoonText(text));
+    if (typeof text === 'string') {
+      const lower = text.toLowerCase();
+      let label = null;
+      let color = '';
+      if (lower.includes('translates light')) {
+        label = 'Translation of Light';
+        color = 'text-blue-600 dark:text-blue-400';
+      } else if (lower.includes('collects light')) {
+        label = 'Collection of Light';
+        color = 'text-green-600 dark:text-green-400';
+      } else if (lower.includes('before perfection')) {
+        label = 'Prohibition';
+        color = 'text-red-600 dark:text-red-400';
+      }
+      if (label) {
+        return (
+          <span>
+            {content}{' '}
+            <span className={`ml-1 text-xs ${color}`}>({label})</span>
+          </span>
+        );
+      }
+    }
+    return content;
   };
   // Transform reasoning if it's still in string format
   const structuredReasoning = useMemo(() => {


### PR DESCRIPTION
## Summary
- Include prohibitor, translator, and collector planet details when evaluating direct timed perfection
- Highlight translation, collection, and prohibition cases in the reasoning renderer
- Add tests covering pass-through of prohibition, translation, and collection data

## Testing
- `pytest`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a6ad42448883248436843b12ab1eda