### PR TITLE
Propagate radicality rule weights to structured reasoning

### DIFF
--- a/codexhorary1/backend/tests/test_reasoning_structuring.py
+++ b/codexhorary1/backend/tests/test_reasoning_structuring.py
@@ -1,6 +1,7 @@
 import pytest
 
 from horary_engine.engine import _structure_reasoning
+from horary_config import cfg
 
 
 def test_structure_reasoning_parses_stage_and_weight():
@@ -13,3 +14,16 @@ def test_structure_reasoning_defaults_when_missing():
     text = "A general observation without extra info"
     result = _structure_reasoning([text])
     assert result == [{"stage": "General", "rule": text, "weight": 0}]
+
+
+def test_structure_reasoning_radicality_weight_inferred():
+    penalty = int(cfg().radicality.asc_warning_penalty)
+    text = "Radicality: Ascendant too early at 2.9° - question premature"
+    result = _structure_reasoning([text])
+    assert result == [
+        {
+            "stage": "Radicality",
+            "rule": f"Ascendant too early at 2.9° - question premature (-{penalty})",
+            "weight": -penalty,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Derive implicit weights for early/late Ascendant radicality warnings
- Expose inferred weights and append them to reasoning text
- Test that radicality penalties are parsed into structured reasoning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6b33760648324a9b6b905eb714252