### PR TITLE
Make backend import package-safe

### DIFF
--- a/codexhorary1/backend/app.py
+++ b/codexhorary1/backend/app.py
@@ -48,7 +48,7 @@ from collections import defaultdict
 
 from horary_engine.engine import HoraryEngine, serialize_planet_with_solar
 from horary_engine.services.geolocation import LocationError
-from evaluate_chart import evaluate_chart
+from .evaluate_chart import evaluate_chart
 from horary_engine.utils import token_to_string
 
 


### PR DESCRIPTION
## Summary
- Add empty `__init__.py` so `backend` is recognized as a package
- Use a relative import for `evaluate_chart` in `backend/app.py`

## Testing
- `python -m backend.app` *(fails: No module named 'horary_engine')*
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a6b74a414c83248e0c60c94df07d3e